### PR TITLE
Changed Darwin platform build options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 /vendor
 /ext/argon2_wrap/libargon2_wrap.so
 /ext/argon2_wrap/tests
+/ext/argon2_wrap/libargon2_wrap.bundle*
 argon2-0.0.2.gem

--- a/ext/argon2_wrap/Makefile
+++ b/ext/argon2_wrap/Makefile
@@ -35,8 +35,8 @@ ifeq ($(KERNEL_NAME), NetBSD)
 	LIB_CFLAGS := -shared -fPIC
 endif
 ifeq ($(KERNEL_NAME), Darwin)
-	LIB_EXT := dylib
-	LIB_CFLAGS := -dynamiclib -install_name @rpath/lib$(LIB_NAME).$(LIB_EXT)
+	LIB_EXT := bundle
+	LIB_CFLAGS := -bundle
 endif
 ifeq ($(findstring MINGW, $(KERNEL_NAME)), MINGW)
 	LIB_EXT := dll


### PR DESCRIPTION
* Swapped out `dylib` extension for `bundle`
* Changed build flags to use just the `-bundle` flag

This PR is meant to address the following issues:
* technion/ruby-argon2#1
* technion/ruby-argon2#3

I've tested on OS X 10.10.5 and this solves the loading errors related to FFI not being able to find the compiled library. I'm going to see if there are ways to improve the build process to make it more resilient. But, this PR resolves those issues you were unable to reproduce.

I'd be happy to contribute my aid on any other Mac-specific issues you have in the future.