### PR TITLE
Ensure that input to 'create' is a string.

### DIFF
--- a/lib/argon2.rb
+++ b/lib/argon2.rb
@@ -18,6 +18,9 @@ module Argon2
     end
 
     def create(pass)
+      raise ArgonHashFail, "Invalid password (expected string)" unless
+        pass.is_a?(String)
+
       Argon2::Engine.hash_argon2i_encode(
               pass, @salt, @t_cost, @m_cost, @secret)
     end


### PR DESCRIPTION
This provides a much clearer error message for other input types (e.g. `nil`, which happens from time to time...).

Currently:

``` ruby
Argon2::Password.create(nil)
# /home/.../gems/argon2-1.1.1/lib/argon2/ffi_engine.rb:59:in `[]': bignum too big to convert into `long' (RangeError)

Argon2::Password.create(1)
# /home/.../gems/argon2-1.1.1/lib/argon2/ffi_engine.rb:51:in `hash_argon2i_encode': undefined method `bytesize' for 1:Integer (NoMethodError)
```

New:

``` ruby
Argon2::Password.create(nil)
# /home/.../gems/argon2-1.1.1/lib/argon2.rb:21:in `create': Invalid password (expected string) (Argon2::ArgonHashFail)
```