### PR TITLE
Added SmartOS / Solaris support.

### DIFF
--- a/ext/argon2_wrap/Makefile
+++ b/ext/argon2_wrap/Makefile
@@ -48,6 +48,12 @@ ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD))
 	LIB_EXT := so
 	LIB_CFLAGS := -shared -fPIC
 endif
+ifeq ($(KERNEL_NAME), SunOS)
+    CC := gcc
+    CFLAGS += -D_REENTRANT
+    LIB_EXT := so
+    LIB_CFLAGS := -shared -fPIC
+endif
 
 LIB_SH := lib$(LIB_NAME).$(LIB_EXT)
 


### PR DESCRIPTION
This is a followup on issue #17 . I just noticed that in order to compile the wrapper the Makefile in the wrapper must also be prepared for SmartOS / Solaris support.