### PR TITLE
Argon2::Password.valid_hash? to support different hashings

### DIFF
--- a/lib/argon2.rb
+++ b/lib/argon2.rb
@@ -32,10 +32,13 @@ module Argon2
       argon2.create(pass)
     end
 
+    # Supports 1 and argon2id formats.
+    def self.valid_hash?(hash)
+      /^\$argon2i.{,113}/ =~ hash
+    end
+
     def self.verify_password(pass, hash, secret = nil)
-      # Supports argon2i and argon2id formats.
-      raise ArgonHashFail, "Invalid hash" unless
-        /^\$argon2i.{,113}/ =~ hash
+      raise ArgonHashFail, "Invalid hash" unless valid_hash?(hash)
 
       Argon2::Engine.argon2_verify(pass, hash, secret)
     end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -33,4 +33,9 @@ class Argon2APITest < Minitest::Test
     assert pass = Argon2::Password.new
     assert pass.create('mypassword')
   end
+
+  def test_valid_hash
+    secure_pass = Argon2::Password.create('A secret')
+    assert Argon2::Password.valid_hash?(secure_pass)
+  end
 end

--- a/test/legacy.rb
+++ b/test/legacy.rb
@@ -11,4 +11,11 @@ class Legacy < Minitest::Test
     assert Argon2::Password.verify_password(PASS, HASH_1_1)
     assert Argon2::Password.verify_password(PASS, HASH_0)
   end
+
+  def test_valid_hash_legacy_hashes
+    # These are the hash formats for 1.0 and 1.1 of this gem.
+    assert Argon2::Password.valid_hash?(PASS, HASH_1_0)
+    assert Argon2::Password.valid_hash?(PASS, HASH_1_1)
+    assert Argon2::Password.valid_hash?(PASS, HASH_0)
+  end
 end


### PR DESCRIPTION
Hey everyone!

I would like to introduce `Argon2::Password.valid_hash?` as a guard so we can easily check which algorithm we should use to match the secret_password and the password provided for the users, as we imported data from different applications which uses different hashing algorithms.

Ref: https://github.com/codahale/bcrypt-ruby/blob/84c8d7b6b5492920631078594d0788f3ca205ecb/lib/bcrypt/password.rb#L49-L51

```ruby
      def valid_hash?(h)
        h =~ /^\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}$/
      end
```