### PR TITLE
Relax version dependency of ffi-compiler

### DIFF
--- a/argon2.gemspec
+++ b/argon2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency 'ffi', '~> 1.9'
-  spec.add_dependency 'ffi-compiler', '~> 0.1'
+  spec.add_dependency 'ffi-compiler', '>= 0.1'
 
   spec.add_development_dependency "bundler", '~> 1.10', '>= 1.10.5'
   spec.add_development_dependency "coveralls", '~> 0.8'


### PR DESCRIPTION
Can you consider relaxing version dependency of `ffi-compiler` from `~> 0.1` to `>= 0.1`?  Its latest release at the time of this writing is 1.0.1, which does not match `~> 0.1`.  I am having difficulties to use ruby-argon2 along with other libraries because of this out-of-date dependency.