### PR TITLE
Added support for argon2d hash verification

### DIFF
--- a/ext/argon2_wrap/argon_wrap.c
+++ b/ext/argon2_wrap/argon_wrap.c
@@ -73,6 +73,8 @@ int argon2_wrap_version(char *out, const char *pwd, size_t pwd_length,
         result = argon2i_ctx(&context);
     }  else if (type == Argon2_id) {
         result = argon2id_ctx(&context);
+    } else if (type == Argon2_d) {
+        result = argon2d_ctx(&context);
     } else {
         // Unsupported type
         return ARGON2_ENCODING_FAIL;
@@ -124,6 +126,8 @@ int wrap_argon2_verify(const char *encoded, const char *pwd,
         type = Argon2_id;
     } else if (memcmp(encoded, "$argon2i", strlen("$argon2i")) == 0) {
         type = Argon2_i;
+    } else if (memcmp(encoded, "$argon2d", strlen("$argon2d")) == 0) {
+        type = Argon2_d;
     } else {
         // Other types not yet supported
         return ARGON2_DECODING_FAIL;

--- a/lib/argon2.rb
+++ b/lib/argon2.rb
@@ -34,7 +34,7 @@ module Argon2
 
     # Supports 1 and argon2id formats.
     def self.valid_hash?(hash)
-      /^\$argon2i.{,113}/ =~ hash
+      /^\$argon2(id?|d).{,113}/ =~ hash
     end
 
     def self.verify_password(pass, hash, secret = nil)

--- a/test/low_level_test.rb
+++ b/test/low_level_test.rb
@@ -74,5 +74,7 @@ class LowLevelArgon2Test < Minitest::Test
     refute Argon2::Engine.argon2_verify("password", "$argon2id$v=19$m=262144,t=2,p=1$c29tZXNhbHQ$eP4eyR+zqlZX1y5xCFTkw9m5GYx0L5YWwvCFvtlbLok", nil)
     assert Argon2::Engine.argon2_verify("password", "$argon2id$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$CTFhFdXPJO1aFaMaO6Mm5c8y7cJHAph8ArZWb2GRPPc", nil)
     refute Argon2::Engine.argon2_verify("notword", "$argon2id$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$CTFhFdXPJO1aFaMaO6Mm5c8y7cJHAph8ArZWb2GRPPc", nil)
+    assert Argon2::Engine.argon2_verify("password", "$argon2d$v=19$m=65536,t=2,p=1$YzI5dFpYTmhiSFFBQUFBQUFBQUFBQQ$Jxy74cswY2mq9y+u+iJcJy8EqOp4t/C7DWDzGwGB3IM", nil)
+    refute Argon2::Engine.argon2_verify("notword", "$argon2d$v=19$m=65536,t=2,p=1$YzI5dFpYTmhiSFFBQUFBQUFBQUFBQQ$Jxy74cswY2mq9y+u+iJcJy8EqOp4t/C7DWDzGwGB3IM", nil)
   end
 end


### PR DESCRIPTION
Hi, I am using an existing database that contains some argon2d hash, so I need to be able to verify them. 

Added argon2d verify support to the gem. 

Wasn't sure where to put my tests. I can move them if need be.

Thanks!