### PR TITLE
Adds support for Windows

### DIFF
--- a/lib/argon2/ffi_engine.rb
+++ b/lib/argon2/ffi_engine.rb
@@ -5,7 +5,7 @@ module Argon2
   # Direct external bindings. Call these methods via the Engine class to ensure points are dealt with
   module Ext
     extend FFI::Library
-    ffi_lib FFI::Compiler::Loader.find('argon2_wrap')
+    ffi_lib FFI::Compiler::Loader.find(FFI::Platform.windows? ? 'libargon2_wrap' : 'argon2_wrap')
 
     # int argon2i_hash_raw(const uint32_t t_cost, const uint32_t m_cost,
     #   const uint32_t parallelism, const void *pwd,


### PR DESCRIPTION
Hi @technion, the library compiles on Windows with [RubyInstaller's Devkit](https://rubyinstaller.org/downloads/) (found this when looking at how the bcrypt gem works on Windows), but it can't find the path to the DLL. This fixes it.

Tested on Windows 10.