### PR TITLE
Add hash format helpers

### DIFF
--- a/lib/argon2.rb
+++ b/lib/argon2.rb
@@ -5,6 +5,7 @@ require 'argon2/ffi_engine'
 require 'argon2/version'
 require 'argon2/errors'
 require 'argon2/engine'
+require 'argon2/hash_format'
 
 module Argon2
   # Front-end API for the Argon2 module.
@@ -37,9 +38,8 @@ module Argon2
       argon2.create(pass)
     end
 
-    # Supports 1 and argon2id formats.
     def self.valid_hash?(hash)
-      /^\$argon2(id?|d).{,113}/ =~ hash
+      Argon2::HashFormat.valid_hash?(hash)
     end
 
     def self.verify_password(pass, hash, secret = nil)

--- a/lib/argon2/hash_format.rb
+++ b/lib/argon2/hash_format.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Argon2
+  ##
+  # Get the values from an Argon2 compatible string.
+  #
+  class HashFormat
+    attr_reader :variant, :version, :t_cost, :m_cost, :p_cost, :salt, :checksum
+
+    # FIXME: Reduce complexity/AbcSize
+    # rubocop:disable Metrics/AbcSize
+    def initialize(digest)
+      digest = digest.to_s unless digest.is_a?(String)
+
+      _, variant, version, config, salt, checksum = digest.split('$')
+      # Regex magic to extract the values for each setting
+      version = /v=(\d+)/.match(version)
+      t_cost  = /t=(\d+),/.match(config)
+      m_cost  = /m=(\d+),/.match(config)
+      p_cost  = /p=(\d+)/.match(config)
+
+      # Make sure none of the values are missing
+      raise Argon2::ArgonHashFail, 'Invalid Argon2 version' if version.nil?
+      raise Argon2::ArgonHashFail, 'Invalid Argon2 time cost' if t_cost.nil?
+      raise Argon2::ArgonHashFail, 'Invalid Argon2 memory cost' if m_cost.nil?
+      raise Argon2::ArgonHashFail, 'Invalid Argon2 parallelism cost' if p_cost.nil?
+
+      @variant  = variant.to_str
+      @version  = version[1].to_i
+      @t_cost   = t_cost[1].to_i
+      @m_cost   = m_cost[1].to_i
+      @p_cost   = p_cost[1].to_i
+      @salt     = salt.to_str
+      @checksum = checksum.to_str
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    ##
+    # Checks whether a given digest is a valid Argon2 hash.
+    #
+    # Supports 1 and argon2id formats.
+    #
+    def self.valid_hash?(digest)
+      /^\$argon2(id?|d).{,113}/ =~ digest
+    end
+  end
+end

--- a/lib/argon2/hash_format.rb
+++ b/lib/argon2/hash_format.rb
@@ -12,6 +12,8 @@ module Argon2
     def initialize(digest)
       digest = digest.to_s unless digest.is_a?(String)
 
+      raise Argon2::ArgonHashFail, 'Invalid Argon2 hash' unless self.class.valid_hash?(digest)
+
       _, variant, version, config, salt, checksum = digest.split('$')
       # Regex magic to extract the values for each setting
       version = /v=(\d+)/.match(version)

--- a/test/hash_format_test.rb
+++ b/test/hash_format_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Argon2HashFormatTest < Minitest::Test
+  OPTIONS = {
+    password: 'My secret password',
+    t_cost: 4,
+    m_cost: 12,
+    p_cost: 3
+  }.freeze
+
+  TEMP = Argon2::Password.new(
+    t_cost: OPTIONS[:t_cost],
+    m_cost: OPTIONS[:m_cost],
+    p_cost: OPTIONS[:p_cost]
+  )
+
+  DIGEST = TEMP.create(OPTIONS[:password])
+
+  def test_hash_format_variant
+    assert argon2 = Argon2::HashFormat.new(DIGEST)
+
+    assert_equal 'argon2id', argon2.variant
+  end
+
+  def test_hash_format_version
+    assert argon2 = Argon2::HashFormat.new(DIGEST)
+
+    assert_equal 19, argon2.version
+  end
+
+  def test_hash_format_t_cost
+    assert argon2 = Argon2::HashFormat.new(DIGEST)
+
+    assert_equal OPTIONS[:t_cost], argon2.t_cost
+  end
+
+  def test_hash_format_m_cost
+    assert argon2 = Argon2::HashFormat.new(DIGEST)
+
+    assert_equal (2**OPTIONS[:m_cost]), argon2.m_cost
+  end
+
+  def test_hash_format_p_cost
+    assert argon2 = Argon2::HashFormat.new(DIGEST)
+
+    assert_equal OPTIONS[:p_cost], argon2.p_cost
+  end
+end

--- a/test/hash_format_test.rb
+++ b/test/hash_format_test.rb
@@ -3,20 +3,15 @@
 require 'test_helper'
 
 class Argon2HashFormatTest < Minitest::Test
+  PASSWORD = 'My secret password'
   OPTIONS = {
-    password: 'My secret password',
     t_cost: 4,
     m_cost: 12,
     p_cost: 3
   }.freeze
 
-  TEMP = Argon2::Password.new(
-    t_cost: OPTIONS[:t_cost],
-    m_cost: OPTIONS[:m_cost],
-    p_cost: OPTIONS[:p_cost]
-  )
-
-  DIGEST = TEMP.create(OPTIONS[:password])
+  TEMP = Argon2::Password.new(OPTIONS)
+  DIGEST = TEMP.create(PASSWORD)
 
   def test_hash_format_variant
     assert argon2 = Argon2::HashFormat.new(DIGEST)


### PR DESCRIPTION
@technion while improving my fork, I ended up extracting the helpers into a separate class that can be included upstream without modifying the password API.